### PR TITLE
Move maintainers from LFAI proposal

### DIFF
--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -1,0 +1,24 @@
+- name: Oleg Avdeev
+  username: oavdeev
+  email: oleg.v.avdeev@gmail.com
+  organization: Tecton
+  
+- name: Pradithya Aria Pura
+  username: pradithya
+  email: pradithya.aria@gmail.com
+  organization: Gojek
+  
+- name: Tsotne Tabidze
+  username: tsotnet
+  email: tsotnet@gmail.com
+  organization: Tecton
+  
+- name: Willem Pienaar
+  username: woop
+  email: git@willem.co
+  organization: Gojek
+  
+- name: Zhiling Chen
+  username: zhilingc
+  email: chnzhlng@gmail.com
+  organization: GetGround


### PR DESCRIPTION
Moving the list of maintainers from the [LFAI proposal](https://github.com/lfai/proposing-projects/blob/master/proposals/feast.adoc) into the Feast community repository.