### PR TITLE
Move maintainers to community repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Welcome to the Feast community!
 Please see the Community section on [Feast.dev](https://docs.feast.dev/) for more details on getting involved.
 
 - [Governance](governance.md): The Feast governance structure
+- [Maintainers](maintainers.yaml): List of members acting as project maintainers

--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -1,0 +1,24 @@
+- name: Oleg Avdeev
+  username: oavdeev
+  email: oleg.v.avdeev@gmail.com
+  organization: Tecton
+
+- name: Pradithya Aria Pura
+  username: pradithya
+  email: pradithya.aria@gmail.com
+  organization: Gojek
+
+- name: Tsotne Tabidze
+  username: tsotnet
+  email: tsotnet@gmail.com
+  organization: Tecton
+
+- name: Willem Pienaar
+  username: woop
+  email: git@willem.co
+  organization: Gojek
+
+- name: Zhiling Chen
+  username: zhilingc
+  email: chnzhlng@gmail.com
+  organization: GetGround


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

Moving the list of maintainers from the [LFAI proposal](https://github.com/lfai/proposing-projects/blob/master/proposals/feast.adoc) into the Feast community repository.